### PR TITLE
Bump to linux610

### DIFF
--- a/.github/workflows/iso_build.yaml
+++ b/.github/workflows/iso_build.yaml
@@ -45,7 +45,7 @@ jobs:
           branch: ${{ matrix.branch }}
           scope: ${{ matrix.scope }}
           version: ${{ steps.time.outputs.time }}-development
-          kernel: linux68
+          kernel: linux610
           code-name: "Nightly-Build"
           release-tag: ${{ needs.prepare-release.outputs.release_tag }}
       -


### PR DESCRIPTION
`linux68` is EOL and dropped from unstable.